### PR TITLE
add error handling for loading of config.yml file

### DIFF
--- a/src/main/java/mc/spigot/weatherbylocation/ServerLocator.java
+++ b/src/main/java/mc/spigot/weatherbylocation/ServerLocator.java
@@ -32,6 +32,11 @@ public class ServerLocator {
         return geolocateIpAddress(ipAddress);
     }
 
+    public LocationData useDefaultLocator() throws IOException, InterruptedException {
+        String ipAddress = fetchIpAddress();
+        return geolocateIPDefault(ipAddress);
+    }
+
     public static boolean isCurrentIpAddress(String ipAddress) {
         Logger logger = Logger.getLogger("WeatherByLocation");
         try {
@@ -79,6 +84,31 @@ public class ServerLocator {
         locationResult.longitude = jsonNode.get("lon").asDouble();
         // copy LocationData object to config.yml
         saveDataToConfig(ipAddress, locationResult);
+        // Log result
+        logger.info(String.format("Server location identified as %s, %s, %s at coordinates (%.3f, %.3f)", locationResult.city, locationResult.region, locationResult.countryCode, locationResult.latitude, locationResult.longitude));
+        return locationResult;
+    }
+
+    private  LocationData geolocateIPDefault(String ipAddress) throws IOException, InterruptedException {
+        Logger logger = Logger.getLogger("WeatherByLocation");
+        String requestUrlString = String.format("http://ip-api.com/json/%s", ipAddress);
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(requestUrlString))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        // Parse JSON response
+        String responseBody = response.body();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        // Create LocationData object and return it
+        LocationData locationResult = new LocationData();
+        locationResult.countryCode = jsonNode.get("countryCode").asText();
+        locationResult.region = jsonNode.get("region").asText();
+        locationResult.city = jsonNode.get("city").asText();
+        locationResult.latitude = jsonNode.get("lat").asDouble();
+        locationResult.longitude = jsonNode.get("lon").asDouble();
+
         // Log result
         logger.info(String.format("Server location identified as %s, %s, %s at coordinates (%.3f, %.3f)", locationResult.city, locationResult.region, locationResult.countryCode, locationResult.latitude, locationResult.longitude));
         return locationResult;

--- a/src/main/java/mc/spigot/weatherbylocation/WeatherByLocation.java
+++ b/src/main/java/mc/spigot/weatherbylocation/WeatherByLocation.java
@@ -1,11 +1,16 @@
 package mc.spigot.weatherbylocation;
 
 import org.bukkit.World;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
+import org.yaml.snakeyaml.parser.ParserException;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -97,6 +102,11 @@ public class WeatherByLocation extends JavaPlugin {
     private void runStartupTasks() {
         // Create default configuration file, if it doesn't exist
         saveDefaultConfig();
+
+        // validate config.yml file
+        boolean configIsValid = validateConfigFile();
+        if (!configIsValid ) return;
+
         // Refresh config
         reloadConfig();
         // Load location data
@@ -215,5 +225,59 @@ public class WeatherByLocation extends JavaPlugin {
         else {
             return WeatherType.CLEAR;
         }
+    }
+
+    private boolean validateConfigFile() {
+        File dataFolder = getDataFolder();
+        // Create a File object for the config.yml file
+        File configFile = new File(dataFolder, "config.yml");
+        var ans= loadConfiguration(configFile);
+        if(ans == null) {
+            getLogger().warning( "An configuration exception occurred. Server will shut down in 15 seconds.");
+            try {
+                Thread.sleep(15000);
+            } catch (InterruptedException ex) {
+                ex.printStackTrace();
+            }
+
+            BukkitScheduler scheduler = getServer().getScheduler();
+            updateWeatherTask = scheduler.runTaskTimerAsynchronously(this, () -> {
+            }, 0L, (20L * 60 * minutesBetweenUpdates));
+
+            Bukkit.shutdown();
+            return false;
+        }
+        return true ;
+    }
+
+
+
+    public  YamlConfiguration loadConfiguration(File file) {
+
+        if (file == null) {
+            // File is null
+            getLogger().warning( "Config File is found to be null, please make sure config file is valid");
+            return null;
+        }
+
+        YamlConfiguration config = new YamlConfiguration();
+
+        try {
+            config.load(file);
+        } catch (FileNotFoundException ex) {
+            getLogger().warning( "Config File is not found , please ensure that file exists");
+            return null;
+        } catch (IOException ex) {
+            getLogger().warning( "IO Exception was found in the loading of config file, please review for any issues");
+            return null;
+        } catch (ParserException ex) {
+            getLogger().warning( "Config File is found to have issues with parsing, possibly the syntax of the config.yml, please review contents");
+            return null;
+        }catch (InvalidConfigurationException ex) {
+            getLogger().warning( "Config File is found to have invalid configuration, please review contents");
+            return null;
+        }
+
+        return config;
     }
 }


### PR DESCRIPTION
- Regarding the current code we have, it appears that when the config.yml file is initially loaded, it is done so within the reloadConfig() function. Upon examining the source code, it seems that this function does not explicitly throw any exceptions (see JavaPlugin.class) but somewhere inside it errors are handled.

- I attempted to replicate and tweak its behavior in WeatherByLocation.java to gain more control However, my attempts were unsuccessful. Despite utilizing a broad try-catch-block such as using (Exception e), I continued to encounter exceptions such as InvalidConfigurationException and others, apparently frontrunning my own error handling logic. It appeared that Bukkit's error handling took precedence over my implementation, testing was done with a misaligned test config file.

- During my search, I discovered that Bukkit employs a mechanism (although specifics remain unclear) where YamlConfiguration and its associated exceptions preemptively intercept mine during the loadConfiguration() process. To get around this I implemented a custom version of loadConfiguration(). This change gave us with greater control over handling the desired exceptions during the configuration loading process.

- So as of now it is unclear which exceptions should be caught ( current have FileNotFoundException,IOException, ParserException, InvalidConfigurationException ). Any feedback in this regard would be greatly appreciated.
 
- Additionally, it remains uncertain whether the server should terminate upon getting a bad configuration file - currently we are waiting 15 seconds then shutting down the server, otherwise we will run into the function that causes issues (reloadConfig() and or others) and we will see a bunch of exceptions).
 
- The way that the shutdown is done is not pretty so i am looking for alternatives, but this is the best i have for now.
 
- It is also probable that a custom class may be needed for the handling of config errors if we are to add more logic to the loadConfiguration() in order to avoid the WeatherByLocation.java being too busy with a slew of helper methods.